### PR TITLE
chore: integrate adonisjs application to docker

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.9'
+
+services:
+  database:
+    image: mysql
+    platform: linux/x86_64
+    container_name: louve_backend
+    command: --default-authentication-plugin=mysql_native_password
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 'secret'
+      MYSQL_DATABASE: 'adonis'
+    ports:
+      - '3306:3306'


### PR DESCRIPTION
Resolved issue #16 

**Setup**

1. Install [Docker Compose](https://docs.docker.com/compose/install/)
2. Create container with MySQL -->  ```$ docker-compose up -d ```

Adonis will create a docker container at local port 3306. If you are using this port, just redirect changing the archive docker-compose.yml (ex.: - '3306:3306' --> - '3307:3306')