### PR TITLE
chore: create first migration to content table

### DIFF
--- a/backend/database/migrations/1631837774835_posts.ts
+++ b/backend/database/migrations/1631837774835_posts.ts
@@ -1,0 +1,21 @@
+import BaseSchema from '@ioc:Adonis/Lucid/Schema'
+
+export default class Posts extends BaseSchema {
+  protected tableName = 'posts'
+
+  public async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.string('title').notNullable()
+      table.string('author')
+      table.text('lyric', 'longtext').notNullable()
+      table.string('cipher_link')
+      table.timestamp('created_at', { useTz: true })
+      table.timestamp('updated_at', { useTz: true })
+    })
+  }
+
+  public async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}


### PR DESCRIPTION
Resolved issue #18 

Execute `node ace migration:run` to create a table called **posts**.
The table contains the following columns:
<!DOCTYPE html><meta http-equiv="content-type" content="text/html; charset=utf-8"><figure class="md-table-fig" cid="n72" mdtype="table" style="box-sizing: border-box; margin: 1.2em 0px; overflow-x: auto; max-width: calc(100% + 16px); padding: 0px; cursor: default; color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><br class="Apple-interchange-newline">

id | title | author | lyric | cipher_link | created_at | updated_at
-- | -- | -- | -- | -- | -- | --


</figure><br class="Apple-interchange-newline">

The collumns **title** and **lyric** cannot be nullable;
The collumns **id**, **created_at** and **updated_at**  are automatically filled;
The collumns **author** and **cipher_link** are optionals.